### PR TITLE
Implement auto layout constraints

### DIFF
--- a/QuizIphone/QuizIphone/Base.lproj/Main.storyboard
+++ b/QuizIphone/QuizIphone/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="elq-s1-vGS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="elq-s1-vGS">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,27 +16,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k1q-Yb-tIH">
-                                <rect key="frame" x="16" y="86" width="343" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="k1q-Yb-tIH">
+                                <rect key="frame" x="16" y="86" width="343" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FZ7-jv-h6U">
-                                <rect key="frame" x="16" y="124" width="343" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FZ7-jv-h6U">
+                                <rect key="frame" x="16" y="128" width="343" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUr-NH-oOS">
-                                <rect key="frame" x="16" y="162" width="343" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Day" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZUr-NH-oOS">
+                                <rect key="frame" x="16" y="170" width="343" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ysT-bJ-60j">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ysT-bJ-60j">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                                 <color key="backgroundColor" red="1" green="0.96397321859999996" blue="0.077739173999999994" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <items>
                                     <navigationItem title="detail" id="G8E-02-dWF">
@@ -56,6 +52,20 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="ysT-bJ-60j" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="5XO-kr-7r9"/>
+                            <constraint firstItem="FZ7-jv-h6U" firstAttribute="top" secondItem="k1q-Yb-tIH" secondAttribute="bottom" constant="8" id="7WM-5C-WmB"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="FZ7-jv-h6U" secondAttribute="trailing" constant="16" id="AAl-B2-iLn"/>
+                            <constraint firstItem="FZ7-jv-h6U" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="BPA-A7-nP3"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="k1q-Yb-tIH" secondAttribute="trailing" constant="16" id="GGf-bP-ACz"/>
+                            <constraint firstItem="ZUr-NH-oOS" firstAttribute="top" secondItem="FZ7-jv-h6U" secondAttribute="bottom" constant="8" id="JHQ-sm-fdu"/>
+                            <constraint firstItem="k1q-Yb-tIH" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="SA5-my-rQi"/>
+                            <constraint firstItem="ysT-bJ-60j" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="Sej-tI-Qti"/>
+                            <constraint firstItem="ZUr-NH-oOS" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="16" id="YZR-0G-8W6"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="ZUr-NH-oOS" secondAttribute="trailing" constant="16" id="bdt-Fy-fHo"/>
+                            <constraint firstItem="ysT-bJ-60j" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" id="oD5-ZY-q2g"/>
+                            <constraint firstItem="k1q-Yb-tIH" firstAttribute="top" secondItem="ysT-bJ-60j" secondAttribute="bottom" constant="30" id="tdV-Ox-Qd1"/>
+                        </constraints>
                     </view>
                     <toolbarItems/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
@@ -80,34 +90,47 @@
                         <color key="sectionIndexBackgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="cellTable" id="26y-VQ-fvn" customClass="YouTableViewCell" customModule="QuizIphone">
-                                <rect key="frame" x="0.0" y="24.5" width="375" height="43.5"/>
+                                <rect key="frame" x="0.0" y="44.5" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="26y-VQ-fvn" id="fyO-8v-Sp5">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fmh-hh-N7g">
-                                            <rect key="frame" x="8" y="14" width="73" height="21"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Fmh-hh-N7g">
+                                            <rect key="frame" x="8" y="11.5" width="73" height="21"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="73" id="Bhs-87-Yrd"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Lq-Od-JaG">
-                                            <rect key="frame" x="79" y="14" width="42" height="21"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5bd-UG-LCV">
+                                            <rect key="frame" x="280" y="12" width="87" height="20.5"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="87" id="dRB-i2-0ta"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5bd-UG-LCV">
-                                            <rect key="frame" x="280" y="14" width="87" height="21"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4Lq-Od-JaG">
+                                            <rect key="frame" x="85" y="12" width="191" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="Fmh-hh-N7g" firstAttribute="top" secondItem="fyO-8v-Sp5" secondAttribute="top" constant="11.5" id="2MI-Kg-soZ"/>
+                                        <constraint firstItem="5bd-UG-LCV" firstAttribute="centerY" secondItem="4Lq-Od-JaG" secondAttribute="centerY" id="3Sn-Kr-WjY"/>
+                                        <constraint firstAttribute="bottom" secondItem="Fmh-hh-N7g" secondAttribute="bottom" constant="11.5" id="Dr4-32-x5i"/>
+                                        <constraint firstItem="4Lq-Od-JaG" firstAttribute="centerY" secondItem="Fmh-hh-N7g" secondAttribute="centerY" id="HZG-bA-Nin"/>
+                                        <constraint firstItem="Fmh-hh-N7g" firstAttribute="leading" secondItem="fyO-8v-Sp5" secondAttribute="leading" constant="8" id="Tl5-hY-8zj"/>
+                                        <constraint firstItem="4Lq-Od-JaG" firstAttribute="leading" secondItem="Fmh-hh-N7g" secondAttribute="trailing" constant="4" id="XzL-HG-TYO"/>
+                                        <constraint firstAttribute="trailing" secondItem="5bd-UG-LCV" secondAttribute="trailing" constant="8" id="eTf-RV-8jl"/>
+                                        <constraint firstItem="5bd-UG-LCV" firstAttribute="leading" secondItem="4Lq-Od-JaG" secondAttribute="trailing" constant="4" id="wJp-Rh-EJv"/>
+                                    </constraints>
                                 </tableViewCellContentView>
                                 <color key="backgroundColor" red="1" green="0.96397321859999996" blue="0.077739173999999994" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>


### PR DESCRIPTION
Hi @KukangSulap, this UI only fits the dimensions of the iPhone SE. In this PR I added auto layout constraint.
Tested on **iPod touch 7th generation**

| Before | After |
| ------ | ------ |
| ![Simulator Screen Shot - iPod touch (7th generation) - 2021-10-08 at 13 57 24](https://user-images.githubusercontent.com/47731450/136514626-99d518b4-c74b-4e11-91e7-215f080fb7b9.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2021-10-08 at 13 58 59](https://user-images.githubusercontent.com/47731450/136515064-c99b2ae4-7cb5-4aa2-9448-40544f4a3911.png) |
| ![Simulator Screen Shot - iPod touch (7th generation) - 2021-10-08 at 14 01 03](https://user-images.githubusercontent.com/47731450/136515203-5084e775-093b-4865-a685-c6bdf7c1f8f5.png) | ![Simulator Screen Shot - iPod touch (7th generation) - 2021-10-08 at 14 04 54](https://user-images.githubusercontent.com/47731450/136515235-37f7c0b1-a3af-4d4e-bebb-2eb4d94e52b3.png) |
 
